### PR TITLE
feat: add deploy-testnet make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ test:
 build:
 	cargo build --target wasm32-unknown-unknown --release
 
+deploy-testnet:
+	@echo "Deploying invoice_nft contract to Stellar Testnet..."
+	@CONTRACT_ID=$$(soroban contract deploy \
+		--wasm target/wasm32-unknown-unknown/release/invoice_nft.wasm \
+		--source alice \
+		--network testnet); \
+	echo "Contract deployed successfully!"; \
+	echo "Contract ID: $$CONTRACT_ID"
+
 fmt:
 	cargo fmt --all
 


### PR DESCRIPTION
- Add deploy-testnet target to Makefile
- Execute soroban contract deploy with invoice_nft.wasm
- Use alice as source account and testnet network
- Echo contract ID for easy copying
- Simplifies deployment process from manual CLI commands

Fixes #3