### PR TITLE
feat: admin ownership transfer and dynamic volatility fee multiplier

### DIFF
--- a/contracts/amm_factory/src/lib.rs
+++ b/contracts/amm_factory/src/lib.rs
@@ -20,6 +20,7 @@ pub enum DataKey {
     Pools, // Map of (TokenA, TokenB) -> Pool
     PoolWasmHash, // The Wasm hash of the Pool contract to deploy
     Admin, // The address of the factory admin
+    PendingAdmin, // The address of the proposed new admin (two-step transfer)
     TotalPools, // The total number of pools deployed
 }
 
@@ -184,6 +185,49 @@ impl FactoryContract {
         env.events().publish(
             (symbol_short!("Admin"), symbol_short!("SetFeeTo")),
             (old_fee_to, fee_to)
+        );
+    }
+
+    /// Proposes a new admin address for a two-step ownership transfer.
+    /// Only the current admin can call this. The proposed address must then call
+    /// `accept_admin` to complete the transfer, preventing accidental key burns.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `new_admin` - The address being proposed as the new admin.
+    pub fn propose_admin(env: Env, new_admin: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+
+        env.events().publish(
+            (symbol_short!("Admin"), symbol_short!("Proposed")),
+            new_admin
+        );
+    }
+
+    /// Completes the two-step admin ownership transfer.
+    /// Must be called by the address previously set via `propose_admin`.
+    /// This confirms the new admin's key is accessible before relinquishing control.
+    ///
+    /// # Panics
+    /// If there is no pending admin proposal, or the caller is not the pending admin.
+    pub fn accept_admin(env: Env) {
+        let pending_admin: Address = env.storage().instance()
+            .get(&DataKey::PendingAdmin)
+            .expect("No pending admin proposal");
+        pending_admin.require_auth();
+
+        let old_admin: Address = env.storage().instance().get(&DataKey::Admin).expect("Not initialized");
+
+        env.storage().instance().set(&DataKey::Admin, &pending_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+
+        // Emit AdminTransferred event so indexers and frontends can track ownership changes
+        env.events().publish(
+            (symbol_short!("Admin"), Symbol::new(&env, "Transferred")),
+            (old_admin, pending_admin)
         );
     }
 

--- a/contracts/amm_factory/src/tests.rs
+++ b/contracts/amm_factory/src/tests.rs
@@ -99,3 +99,43 @@ fn test_pair_exists_on_uninitialized_factory() {
     // Factory not initialized - should return false (empty map)
     assert_eq!(client.pair_exists(&token_a, &token_b), false);
 }
+
+#[test]
+fn test_propose_and_accept_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let factory_id = env.register_contract(None, FactoryContract);
+    let client = FactoryContractClient::new(&env, &factory_id);
+
+    let admin = Address::generate(&env);
+    let fee_to = Address::generate(&env);
+    let wasm_hash = BytesN::from_array(&env, &[0; 32]);
+    client.initialize_factory(&admin, &fee_to, &wasm_hash);
+
+    let new_admin = Address::generate(&env);
+
+    // Current admin proposes a new admin
+    client.propose_admin(&new_admin);
+
+    // New admin accepts — ownership transfers
+    client.accept_admin();
+}
+
+#[test]
+fn test_accept_admin_panics_with_no_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let factory_id = env.register_contract(None, FactoryContract);
+    let client = FactoryContractClient::new(&env, &factory_id);
+
+    let admin = Address::generate(&env);
+    let fee_to = Address::generate(&env);
+    let wasm_hash = BytesN::from_array(&env, &[0; 32]);
+    client.initialize_factory(&admin, &fee_to, &wasm_hash);
+
+    // No proposal made — accept_admin must fail
+    let result = client.try_accept_admin();
+    assert!(result.is_err(), "accept_admin must fail when no proposal exists");
+}

--- a/contracts/amm_pool/src/lib.rs
+++ b/contracts/amm_pool/src/lib.rs
@@ -517,4 +517,46 @@ impl AmmPool {
         }
         x
     }
+
+    /// Calculate a volatility fee multiplier based on the ratio of a trade size to the pool reserve.
+    ///
+    /// This protects Liquidity Providers (LPs) from impermanent loss during extreme market events.
+    /// Large trades relative to pool depth cause significant price impact and expose LPs to
+    /// arbitrage losses. By increasing the fee for large trades, the protocol compensates LPs
+    /// for the elevated risk they bear during high-volatility periods.
+    ///
+    /// # Multiplier Logic
+    /// The return value is scaled by 100 to avoid floating-point arithmetic on-chain:
+    /// - `100` represents a multiplier of 1.0 (standard fee, no adjustment)
+    /// - `150` represents a multiplier of 1.5 (50% fee increase for high-impact trades)
+    ///
+    /// # Thresholds
+    /// - `trade_size < 1% of pool_reserve`  → multiplier = 1.0 (return 100)
+    ///   Small trades have negligible price impact; standard fee applies.
+    /// - `trade_size > 5% of pool_reserve`  → multiplier = 1.5 (return 150)
+    ///   Large trades cause significant slippage and impermanent loss risk for LPs.
+    /// - `1% ≤ trade_size ≤ 5%`             → multiplier = 1.0 (return 100)
+    ///   Medium trades fall within the standard fee band.
+    ///
+    /// # Arguments
+    /// * `trade_size`   - The size of the incoming trade (in the input token's native units).
+    /// * `pool_reserve` - The current reserve of the input token in the pool.
+    ///
+    /// # Returns
+    /// A `u32` multiplier scaled by 100: either `100` (1.0×) or `150` (1.5×).
+    pub fn calculate_volatility_fee_multiplier(trade_size: i128, pool_reserve: i128) -> u32 {
+        // Guard: if reserve is zero or inputs are non-positive, return standard multiplier
+        if pool_reserve <= 0 || trade_size <= 0 {
+            return 100;
+        }
+
+        // Check if trade_size > 5% of pool_reserve
+        // Equivalent to: trade_size * 100 > pool_reserve * 5
+        // Using integer arithmetic to avoid division and floating-point
+        if trade_size.saturating_mul(100) > pool_reserve.saturating_mul(5) {
+            return 150; // 1.5× multiplier — high-volatility trade, protect LPs
+        }
+
+        100 // 1.0× multiplier — standard fee applies
+    }
 }

--- a/contracts/amm_pool/src/tests.rs
+++ b/contracts/amm_pool/src/tests.rs
@@ -729,3 +729,66 @@ fn test_calculate_single_sided_deposit_split() {
     // s ≈ 500.62 for this depth. Integer floor is 500.
     assert_eq!(swap_amount, 500);
 }
+
+// ── Unit tests for calculate_volatility_fee_multiplier ───────────────────────
+
+/// Trade < 1% of reserve → standard multiplier (100 = 1.0×)
+#[test]
+fn test_volatility_multiplier_small_trade_returns_100() {
+    // trade_size = 0.5% of reserve → below 1% threshold
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(5, 1000);
+    assert_eq!(multiplier, 100);
+}
+
+/// Trade exactly at 1% boundary → standard multiplier (100 = 1.0×)
+#[test]
+fn test_volatility_multiplier_at_1_percent_returns_100() {
+    // trade_size = 1% of reserve (10 / 1000 = 1%)
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(10, 1000);
+    assert_eq!(multiplier, 100);
+}
+
+/// Trade between 1% and 5% → standard multiplier (100 = 1.0×)
+#[test]
+fn test_volatility_multiplier_medium_trade_returns_100() {
+    // trade_size = 3% of reserve (30 / 1000 = 3%)
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(30, 1000);
+    assert_eq!(multiplier, 100);
+}
+
+/// Trade exactly at 5% boundary → standard multiplier (100 = 1.0×)
+#[test]
+fn test_volatility_multiplier_at_5_percent_returns_100() {
+    // trade_size = 5% of reserve (50 / 1000 = 5%)
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(50, 1000);
+    assert_eq!(multiplier, 100);
+}
+
+/// Trade > 5% of reserve → high-volatility multiplier (150 = 1.5×)
+#[test]
+fn test_volatility_multiplier_large_trade_returns_150() {
+    // trade_size = 6% of reserve (60 / 1000 = 6%)
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(60, 1000);
+    assert_eq!(multiplier, 150);
+}
+
+/// Very large trade (50% of reserve) → high-volatility multiplier (150 = 1.5×)
+#[test]
+fn test_volatility_multiplier_very_large_trade_returns_150() {
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(500, 1000);
+    assert_eq!(multiplier, 150);
+}
+
+/// Zero trade size → standard multiplier (guard clause)
+#[test]
+fn test_volatility_multiplier_zero_trade_returns_100() {
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(0, 1000);
+    assert_eq!(multiplier, 100);
+}
+
+/// Zero reserve → standard multiplier (guard clause, avoids division by zero)
+#[test]
+fn test_volatility_multiplier_zero_reserve_returns_100() {
+    let multiplier = AmmPool::calculate_volatility_fee_multiplier(100, 0);
+    assert_eq!(multiplier, 100);
+}


### PR DESCRIPTION
## Summary

Resolves both issues assigned to Xuccessor in a single PR.

Closes #63
Closes #76

---

## Issue #63 — Two-step Admin Ownership Transfer (`amm_factory`)

**Problem:** The admin address is set once at initialization. A lost or compromised key permanently orphans the protocol.

**Changes (`contracts/amm_factory/src/lib.rs`):**
- Added `PendingAdmin` variant to `DataKey` enum (instance storage)
- `propose_admin(new_admin)` — restricted to current admin; stores the candidate in `PendingAdmin`
- `accept_admin()` — callable only by the pending admin; atomically promotes them to `Admin`, clears `PendingAdmin`, and emits an `AdminTransferred` event

The two-step pattern prevents accidental key burns: the new admin must prove their key is accessible before the old admin loses control.

## Issue #76 — Dynamic Volatility Fee Multiplier (`amm_pool`)

**Problem:** A static fee does not protect LPs from impermanent loss during large, unbalanced trades.

**Changes (`contracts/amm_pool/src/lib.rs`):**
- Added `calculate_volatility_fee_multiplier(trade_size, pool_reserve) -> u32`
- Returns `100` (1.0×, standard fee) when `trade_size ≤ 5%` of `pool_reserve`
- Returns `150` (1.5×, elevated fee) when `trade_size > 5%` of `pool_reserve`
- Guard clauses handle zero/negative inputs safely
- Detailed inline documentation explains the LP-protection rationale

The return value is scaled by 100 to avoid floating-point arithmetic on-chain.

## Tests

- `amm_factory/tests.rs`: `test_propose_and_accept_admin`, `test_accept_admin_panics_with_no_proposal`
- `amm_pool/tests.rs`: 8 unit tests covering all threshold boundaries and guard clauses for `calculate_volatility_fee_multiplier`